### PR TITLE
[BUGFIX] Strict Notices in Magento var/log/system.log

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
@@ -40,9 +40,9 @@ class Yireo_GoogleTagManager_Block_Default extends Mage_Core_Block_Template
         return json_encode($attributes);
     }
 
-    public function setAttribute($name, $value)
+    public function setAttribute($name, $value = null)
     {
-        Mage::getSingleton('googletagmanager/container')->setData($name, $value);
+        return Mage::getSingleton('googletagmanager/container')->setData($name, $value);
     }
 
     public function getAttributes()


### PR DESCRIPTION
Bug fix for the following notices in Magento var/log/system.log:
Strict Notice: Declaration of Yireo_GoogleTagManager_Block_Default::setAttribute() should be compatible with Mage_Core_Block_Abstract::setAttribute($name, $value = NULL)
