### PR TITLE
Prevent two "Google tag assistant notices"

### DIFF
--- a/source/app/design/frontend/base/default/template/googletagmanager/default.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/default.phtml
@@ -9,6 +9,9 @@
  */
 ?>
 <?php if($this->isEnabled()) : ?>
+
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=<?php echo $this->getId(); ?>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <?php $childScript = $this->getChildScript(); ?>
 <?php if(!empty($childScript)) : ?>
 <script>
@@ -18,5 +21,10 @@ dataLayer = [<?php echo $this->getAttributesAsJson(); ?>];
 <?php echo $childScript; ?>
 </script>
 <?php endif; ?>
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=<?php echo $this->getId(); ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','<?php echo $this->getId(); ?>');</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+{'gtm.start': new Date().getTime(),event:'gtm.js'}
+);var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<?php echo $this->getId(); ?>');</script>
 <?php endif; ?>

--- a/source/app/design/frontend/base/default/template/googletagmanager/order.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/order.phtml
@@ -13,9 +13,9 @@
 <?php if(!empty($order) && $order->getId() > 0) : ?>
     <?php $this->addAttribute('transactionId', $order->getIncrementId()); ?>
     <?php $this->addAttribute('transactionAffiliation', Mage::app()->getWebsite()->getName()); ?>
-    <?php $this->addAttribute('transactionTotal', $order->getGrandTotal()); ?>
+    <?php $this->addAttribute('transactionTotal', (float)$order->getGrandTotal()); ?>
     <?php $this->addAttribute('transactionTax', $order->getGrandTotal() - $order->getSubtotal()); ?>
-    <?php $this->addAttribute('transactionShipping', $order->getShippingAmount()); ?>
+    <?php $this->addAttribute('transactionShipping', (float)$order->getShippingAmount()); ?>
     <?php $this->addAttribute('transactionProducts', $this->getItemsAsJson()); ?>
 <?php endif; ?>
 <?php endif; ?>

--- a/source/app/design/frontend/base/default/template/googletagmanager/quote.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/quote.phtml
@@ -13,7 +13,7 @@
 <?php if(!empty($quote) && $quote->getId() > 0) : ?>
     <?php $this->addAttribute('transactionId', $quote->getId()); ?>
     <?php $this->addAttribute('transactionAffiliation', Mage::app()->getWebsite()->getName()); ?>
-    <?php $this->addAttribute('transactionTotal', $quote->getGrandTotal()); ?>
+    <?php $this->addAttribute('transactionTotal', (float)$quote->getGrandTotal()); ?>
     <?php $this->addAttribute('transactionTax', $quote->getGrandTotal() - $quote->getSubtotal()); ?>
     <?php $this->addAttribute('transactionProducts', $this->getItemsAsJson()); ?>
 <?php endif; ?>


### PR DESCRIPTION
Google tag assistant gives two notices when using this module. Converting the two values to a float fixes the issue.

![tagmanager-notices](https://cloud.githubusercontent.com/assets/3979/7454764/2c3ff990-f277-11e4-8fc7-4f41c41e8fa2.png)
