### PR TITLE
ADD transactionSubtotal to order's datalayer. To get net prices in all tax/shipping scenarios.

### DIFF
--- a/source/app/design/frontend/base/default/template/googletagmanager/order.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/order.phtml
@@ -14,6 +14,7 @@
         <?php $this->addAttribute('transactionId', $order->getIncrementId()); ?>
         <?php $this->addAttribute('transactionAffiliation', Mage::app()->getWebsite()->getName()); ?>
         <?php $this->addAttribute('transactionTotal', $order->getGrandTotal()); ?>
+        <?php $this->addAttribute('transactionSubtotal', $order->getSubtotal()); ?>
         <?php $this->addAttribute('transactionTax', $order->getGrandTotal() - $order->getSubtotal()); ?>
         <?php $this->addAttribute('transactionShipping', $order->getShippingAmount()); ?>
         <?php $this->addAttribute('transactionProducts', $this->getItems()); ?>


### PR DESCRIPTION
...there are tax scenarios where the current calculation (transactionTax) is not correct. 
Kind of workaround to access the subtotal directly.
