### PR TITLE
Prevent two "Google tag assistant notices"

### DIFF
--- a/source/app/design/frontend/base/default/template/googletagmanager/order.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/order.phtml
@@ -15,10 +15,10 @@
         <?php $this->addAttribute('transactionId', $order->getIncrementId()); ?>
         <?php $this->addAttribute('transactionDate', $order->getCreatedAt()); ?>
         <?php $this->addAttribute('transactionAffiliation', Mage::app()->getWebsite()->getName()); ?>
-        <?php $this->addAttribute('transactionTotal', $order->getGrandTotal()); ?>
-        <?php $this->addAttribute('transactionSubtotal', $order->getSubtotal()); ?>
+        <?php $this->addAttribute('transactionTotal', (float)$order->getGrandTotal()); ?>
+        <?php $this->addAttribute('transactionSubtotal', (float)$order->getSubtotal()); ?>
         <?php $this->addAttribute('transactionTax', $order->getGrandTotal() - $order->getSubtotal()); ?>
-        <?php $this->addAttribute('transactionShipping', $order->getShippingAmount()); ?>
+        <?php $this->addAttribute('transactionShipping', (float)$order->getShippingAmount()); ?>
         <?php $this->addAttribute('transactionPayment', $order->getPayment()->getMethodInstance()->getTitle()); ?>
         <?php $this->addAttribute('transactionCurrency', Mage::app()->getStore()->getBaseCurrencyCode()); ?>
         <?php $this->addAttribute('transactionPromoCode', $order->getCouponCode()); ?>


### PR DESCRIPTION
This is the error google tag assistant reported: 'Number field should not be quoted:'

I commited this fix once before but I think it got overwritten by another commit.
