### PR TITLE
Fixed Observer Insertion Method

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Helper/Data.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Helper/Data.php
@@ -19,7 +19,7 @@ class Yireo_GoogleTagManager_Helper_Data extends Mage_Core_Helper_Abstract
             return false;
         }
 
-        return (bool)$this->getConfigValue('enabled');
+        return (bool)$this->getConfigValue('active');
     }
 
     /**


### PR DESCRIPTION
In your `Observer.php`, you use the helper method of getting the config values. There, the `enabled` config value is checked. But the config value is named `active`.
