### PR TITLE
Set default order/direction on category product collection.

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Category.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Category.php
@@ -32,7 +32,13 @@ class Yireo_GoogleTagManager_Block_Category extends Yireo_GoogleTagManager_Block
         if ($this->getLimit() != 'all') {
             $collection->setCurPage($this->getCurrentPage())->setPageSize($this->getLimit());
         }
-        
+
+        // Set default order/direction, failing to do so will prevent proper default order/direction on category views
+        // ($this->_isOrdersRendered already set in resource collection but no sorting applied)
+        if ($productListBlock->getSortBy()) {
+            $collection->setOrder($productListBlock->getSortBy(), $productListBlock->getDefaultDirection());
+        }
+
         return $collection;
     }
 


### PR DESCRIPTION
Currently the GoogleTagManager extension breaks default order/sorting on category pages. This was a rather nasty bug to locate, as I got the bug report for this only months after we installed the extension.

By using the product collection of `Mage_Catalog_Block_Product_List` you essentially initialize it's collection cache but without any order/sorting applied. These collections then get later reused but as the `$this->_isOrdersRendered` flag of the collection is already set, any applied order/sorting will silently be ignored.
