### PR TITLE
Fixed Possible SQL Error

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Search.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Search.php
@@ -33,7 +33,9 @@ class Yireo_GoogleTagManager_Block_Search extends Yireo_GoogleTagManager_Block_C
             $collection->setCurPage($this->getCurrentPage())->setPageSize($this->getLimit());
         }
 
-        $collection->setOrder($searchListBlock->getSortBy(), $searchListBlock->getDefaultDirection());
+        if ($searchListBlock->getSortBy()) {
+            $collection->setOrder($searchListBlock->getSortBy(), $searchListBlock->getDefaultDirection());
+        }
 
         return $collection;
     }


### PR DESCRIPTION
`$searchListBlock->getSortBy()` may return an empty string or null, which breaks the SQL (resulting in a fatal error!). The order should only be set if it is available. Similar to `Yireo_GoogleTagManager_Block_Category::getProductCollection`.
