### PR TITLE
Fix for names containing ' causing JS Error

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
@@ -175,7 +175,7 @@ class Yireo_GoogleTagManager_Block_Default extends Mage_Core_Block_Template
      */
     public function jsonEncode($data)
     {
-        $string = json_encode($data);
+        $string = json_encode($data, JSON_HEX_APOS);
         $string = str_replace('"', "'", $string);
         return $string;
     }


### PR DESCRIPTION
I'm not sure why you want to switch from double to single quotes, but if you do so by str_replace, you first need to ensure that there aren't any single quotes in the strings...

Bug appeared on product detail and add to cart for a product with name: Fischer's Nähstudio Nähmaschinentasche
This fix seems to work for all cases.
