### PR TITLE
Prevent global caching of GTM-Blocks as they can include transaction based data

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
@@ -38,8 +38,6 @@ class Yireo_GoogleTagManager_Block_Default extends Mage_Core_Block_Template
      */
     protected function _construct()
     {
-        $this->setCacheLifetime(86400);
-
         $this->moduleHelper = Mage::helper('googletagmanager');
         $this->container = Mage::getSingleton('googletagmanager/container');
         $this->layout = Mage::app()->getLayout();


### PR DESCRIPTION
As reported by @gido caching the GTM-Blocks in general prevents transactional data to be generated properly.