### PR TITLE
Google Tag Manager Environments

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Default.php
@@ -233,4 +233,20 @@ class Yireo_GoogleTagManager_Block_Default extends Mage_Core_Block_Template
         }
         return false;
     }
+
+    /**
+     * Get the environment parameters
+     *
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        $environment = '';
+        if ($this->getModuleHelper()->getIsEnvironmentEnabled()) {
+            $auth = $this->getModuleHelper()->getEnvironmentAuth();
+            $preview = $this->getModuleHelper()->getEnvironmentPreview();
+            $environment = sprintf('&gtm_auth=%s&gtm_preview=%s&gtm_cookies_win=x', $auth, $preview);
+        }
+        return $environment;
+    }
 }

--- a/source/app/code/community/Yireo/GoogleTagManager/Helper/Data.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Helper/Data.php
@@ -141,4 +141,34 @@ class Yireo_GoogleTagManager_Helper_Data extends Mage_Core_Helper_Abstract
             return "";
         }
     }
+
+    /**
+     * Returns whether environments is enabled
+     *
+     * @return bool
+     */
+    public function getIsEnvironmentEnabled()
+    {
+        return (bool) $this->getConfigValue('environment_active');
+    }
+
+    /**
+     * Get the auth value
+     *
+     * @return string|null
+     */
+    public function getEnvironmentAuth()
+    {
+        return $this->getConfigValue('auth');
+    }
+
+    /**
+     * Get the preview value
+     *
+     * @return string|null
+     */
+    public function getEnvironmentPreview()
+    {
+        return $this->getConfigValue('preview');
+    }
 }

--- a/source/app/code/community/Yireo/GoogleTagManager/etc/system.xml
+++ b/source/app/code/community/Yireo/GoogleTagManager/etc/system.xml
@@ -62,6 +62,34 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </debug>
+                        <environment_active translate="label">
+                            <label>Enable Environments</label>
+                            <comment>Includes the value of the GTM Auth and GTM Preview fields when loading in Google Tag Manager to allow Environments to be used in Google Tag Manager.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </environment_active>
+                        <auth translate="label">
+                            <label>GTM Auth</label>
+                            <comment>Populates the gtm_auth parameter. Only visible when "Enable Environments" is set to "Yes".</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </auth>
+                        <preview translate="label">
+                            <label>GTM Preview</label>
+                            <comment>Populates the gtm_preview parameter. Only visible when "Enable Environments" is set to "Yes".</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </preview>
                     </fields>
                 </settings>
             </groups>

--- a/source/app/design/frontend/base/default/template/googletagmanager/head.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/head.phtml
@@ -20,8 +20,9 @@
             w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
             if (i == 'DEBUG') return console.log(w[l]);
             var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+            var environment = '<?= $this->getEnvironment(); ?>';
             j.async = true;
-            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + environment;
             f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', '<?= $this->getId(); ?>');
     </script>

--- a/source/app/design/frontend/base/default/template/googletagmanager/noscript.phtml
+++ b/source/app/design/frontend/base/default/template/googletagmanager/noscript.phtml
@@ -14,6 +14,6 @@ $style = 'display:none;visibility:hidden';
 ?>
 <?php if ($this->isEnabled()) : ?>
     <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=<?= $this->getId(); ?>" height="0" width="0" style="<?= $style ?>"></iframe>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=<?= $this->getId() . $this->getEnvironment(); ?>" height="0" width="0" style="<?= $style ?>"></iframe>
     </noscript>
 <?php endif; ?>


### PR DESCRIPTION
Google Tag Manager has introduced a feature that allows for a single GTM account to be contain multiple environments. This allows for a container to be previewed on one environment before being pushed to another all in a single account.

To allow this, we need to include `gtm_auth` and `gtm_preview` parameters on the request.

This change creates three new configuration options:

* Enable Environments
* GTM Auth
* GTM Preview

If "Enable Environments" is set to "Yes" then the values of GTM Auth and GTM Preview will be included.

More information can be found here - https://www.periscopix.co.uk/blog/a-revolution-of-multi-server-testing-by-google-tag-manager-environments/
