### PR TITLE
Check if category path is set in order.php

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php
@@ -105,16 +105,19 @@ class Yireo_GoogleTagManager_Block_Order extends Yireo_GoogleTagManager_Block_De
         foreach ($product->getCategoryIds() as $categoryId) {
             $category = $allCategories[$categoryId];
             $categoryPath = [];
-            foreach ($category['path'] as $pathId) {
-                if ($pathId == 1) {
-                    continue;
-                }
+            
+            if(isset($category['path'])){
+                foreach ($category['path'] as $pathId) {
+                    if ($pathId == 1) {
+                        continue;
+                    }
 
-                if ($pathId === Mage::app()->getStore()->getRootCategoryId()) {
-                    continue;
-                }
+                    if ($pathId === Mage::app()->getStore()->getRootCategoryId()) {
+                        continue;
+                    }
 
-                $categoryPath[] = $allCategories[$pathId]['name'];
+                    $categoryPath[] = $allCategories[$pathId]['name'];
+                }
             }
 
             $categoryPaths[] = implode($categorySeparator, $categoryPath);


### PR DESCRIPTION
Fixes error on checkout success page:

```
Warning: Invalid argument supplied for foreach()  in /var/www/app/code/community/Yireo/GoogleTagManager/Block/Order.php on line 110

#0 /var/www/app/code/community/Yireo/GoogleTagManager/Block/Order.php(110): mageCoreErrorHandler(2, 'Invalid argumen...', '/var/www/app/co...', 110, Array)
#1 /var/www/app/code/community/Yireo/GoogleTagManager/Block/Order.php(87): Yireo_GoogleTagManager_Block_Order->getProductCategoryTrees(Object(Mage_Catalog_Model_Product))
#2 /var/www/app/design/frontend/base/default/template/googletagmanager/data/order.phtml(27): Yireo_GoogleTagManager_Block_Order->getItems()
#3 /var/www/app/code/core/Mage/Core/Block/Template.php(241): include('/var/www/app/de...')
#4 /var/www/app/code/core/Mage/Core/Block/Template.php(272): Mage_Core_Block_Template->fetchView('frontend/base/d...')
#5 /var/www/app/code/core/Mage/Core/Block/Template.php(286): Mage_Core_Block_Template->renderView()
#6 /var/www/app/code/community/Yireo/GoogleTagManager/Block/Default.php(214): Mage_Core_Block_Template->_toHtml()
#7 /var/www/app/code/core/Mage/Core/Block/Abstract.php(923): Yireo_GoogleTagManager_Block_Default->_toHtml()
#8 /var/www/app/code/core/Mage/Core/Block/Abstract.php(641): Mage_Core_Block_Abstract->toHtml()
#9 /var/www/app/code/core/Mage/Core/Block/Abstract.php(581): Mage_Core_Block_Abstract->_getChildHtml('googletagmanage...', true)
#10 /var/www/app/design/frontend/base/default/template/googletagmanager/data.phtml(15): Mage_Core_Block_Abstract->getChildHtml()
#11 /var/www/app/code/core/Mage/Core/Block/Template.php(241): include('/var/www/app/de...')
#12 /var/www/app/code/core/Mage/Core/Block/Template.php(272): Mage_Core_Block_Template->fetchView('frontend/base/d...')
#13 /var/www/app/code/core/Mage/Core/Block/Template.php(286): Mage_Core_Block_Template->renderView()
#14 /var/www/app/code/community/Yireo/GoogleTagManager/Block/Default.php(214): Mage_Core_Block_Template->_toHtml()
#15 /var/www/app/code/core/Mage/Core/Block/Abstract.php(923): Yireo_GoogleTagManager_Block_Default->_toHtml()
#16 /var/www/app/code/community/Yireo/GoogleTagManager/Observer/LazyLoadDataLayer.php(86): Mage_Core_Block_Abstract->toHtml()
#17 /var/www/app/code/community/Yireo/GoogleTagManager/Observer/LazyLoadDataLayer.php(59): Yireo_GoogleTagManager_Observer_LazyLoadDataLayer->appendDataLayer(Object(Mage_Page_Block_Html), Object(Varien_Event))
#18 /var/www/app/code/core/Mage/Core/Model/App.php(1358): Yireo_GoogleTagManager_Observer_LazyLoadDataLayer->execute(Object(Varien_Event_Observer))
#19 /var/www/app/code/core/Mage/Core/Model/App.php(1337): Mage_Core_Model_App->_callObserverMethod(Object(Yireo_GoogleTagManager_Observer_LazyLoadDataLayer), 'execute', Object(Varien_Event_Observer))
#20 /var/www/app/Mage.php(456): Mage_Core_Model_App->dispatchEvent('core_block_abst...', Array)
#21 /var/www/app/code/core/Mage/Core/Block/Abstract.php(947): Mage::dispatchEvent('core_block_abst...', Array)
#22 /var/www/app/code/core/Mage/Core/Model/Layout.php(555): Mage_Core_Block_Abstract->toHtml()
#23 /var/www/app/code/core/Mage/Core/Controller/Varien/Action.php(390): Mage_Core_Model_Layout->getOutput()
#24 /var/www/app/code/core/Mage/Checkout/controllers/OnepageController.php(295): Mage_Core_Controller_Varien_Action->renderLayout()
#25 /var/www/app/code/core/Mage/Core/Controller/Varien/Action.php(418): Mage_Checkout_OnepageController->successAction()
#26 /var/www/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch('success')
#27 /var/www/app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#28 /var/www/app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch()
#29 /var/www/app/Mage.php(692): Mage_Core_Model_App->run(Array)
#30 /var/www/index.php(84): Mage::run('', 'store')
#31 {main}
```