### PR TITLE
Use Quote/Order Item to Retrieve Price (Ensures Compatibility with All Product Types)

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php
@@ -68,11 +68,8 @@ class Yireo_GoogleTagManager_Block_Order extends Yireo_GoogleTagManager_Block_De
             $taxClassId = $product->getTaxClassId();
             $taxpercent = $taxCalculation->getRate($request->setProductClassId($taxClassId));
 
-            $price = $product->getPrice();
-            $specialPrice = $product->getSpecialprice();
-            if (($specialPrice > 0) && ($specialPrice < $price)) {
-                $price = $specialPrice;
-            }
+            $price = $item->getPrice();
+            
             $tax = ($price / (100 + $taxpercent)) * $taxpercent;
 
             $data[] = array(

--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Quote.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Quote.php
@@ -69,11 +69,7 @@ class Yireo_GoogleTagManager_Block_Quote extends Yireo_GoogleTagManager_Block_De
             $taxClassId = $product->getTaxClassId();
             $taxpercent = $taxCalculation->getRate($request->setProductClassId($taxClassId));
 
-            $price = $product->getPrice();
-            $specialPrice = $product->getSpecialprice();
-            if (($specialPrice > 0) && ($specialPrice < $price)) {
-                $price = $specialPrice;
-            }
+            $price = $product->getFinalPrice();
 
             $tax = ($price / (100 + $taxpercent)) * $taxpercent;
 

--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Quote.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Quote.php
@@ -69,7 +69,7 @@ class Yireo_GoogleTagManager_Block_Quote extends Yireo_GoogleTagManager_Block_De
             $taxClassId = $product->getTaxClassId();
             $taxpercent = $taxCalculation->getRate($request->setProductClassId($taxClassId));
 
-            $price = $product->getFinalPrice();
+            $price = $item->getPrice();
 
             $tax = ($price / (100 + $taxpercent)) * $taxpercent;
 


### PR DESCRIPTION
Use the getFinalPrice() method for always retrieving the final price which is handled correctly by Magento to ensure compatibility with all product types. The part comparing with the special price isn't required with this approach and the price is right for configurable products having their price modified through options.