### PR TITLE
Fix missing currency code in checkout

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Helper/Script.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Helper/Script.php
@@ -75,10 +75,8 @@ class Yireo_GoogleTagManager_Helper_Script extends Mage_Core_Helper_Abstract
      */
     public function getEcommerceData()
     {
-        if (empty($this->ecommerceData)) {
-            $this->ecommerceData = array(
-                'currencyCode' => $this->getCurrencyCode(),
-            );
+        if (!isset($this->ecommerceData['currencyCode'])) {
+            $this->ecommerceData['currencyCode'] = $this->getCurrencyCode();
         }
 
         return $this->ecommerceData;


### PR DESCRIPTION
In the checkout, `\Yireo_GoogleTagManager_Helper_Script::addEcommerceData` is called before `\Yireo_GoogleTagManager_Helper_Script::getEcommerceData`. Hence, the old check `empty($this->ecommerceData)` fails and the currency code is not pushed.