### PR TITLE
Make sure order is only tracked once

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Order.php
@@ -27,6 +27,12 @@ class Yireo_GoogleTagManager_Block_Order extends Yireo_GoogleTagManager_Block_De
      */
     public function getOrder()
     {
+        if (Mage::app()->getRequest()->getRouteName() !== 'checkout'
+            || !in_array(Mage::app()->getRequest()->getControllerName(), ['onepage', 'multishipping'], true)
+            || Mage::app()->getRequest()->getActionName() !== 'success') {
+            return null;
+        }
+
         $lastOrderId = $this->getLastOrderId();
         if (empty($lastOrderId)) {
             return null;


### PR DESCRIPTION
The last order ID, which is set on the checkout session, is never cleared. Hence, `Mage::getSingleton('checkout/session')->getLastRealOrderId()` always returns the last real order ID if the user ordered in his current session. Hence, we track the order again and again if the user keeps visiting other pages after checkout success.

This PR makes sure that the order is only tracked on the checkout success page.