### PR TITLE
Fix wrong customer group tracking

### DIFF
--- a/source/app/code/community/Yireo/GoogleTagManager/Block/Customer.php
+++ b/source/app/code/community/Yireo/GoogleTagManager/Block/Customer.php
@@ -29,11 +29,13 @@ class Yireo_GoogleTagManager_Block_Customer extends Yireo_GoogleTagManager_Block
      */
     public function getCustomerGroup()
     {
-        $customer = $this->getCustomer();
+        /** @var Mage_Customer_Model_Session $customerSession */
+        $customerSession = Mage::getSingleton('customer/session');
+        $customerGroupId = $customerSession->getCustomerGroupId();
 
         /** @var Mage_Customer_Model_Group $customerGroup */
         $customerGroup = Mage::getSingleton('customer/group');
-        $customerGroup->load($customer->getGroupId());
+        $customerGroup->load($customerGroupId);
 
         return $customerGroup;
     }


### PR DESCRIPTION
`\Mage_Customer_Model_Customer::getGroupId` returns the default customer group ID if the customer is not logged in. Hence, for not logged in customers, the default customer group is currently tracked. Instead, "not logged in" needs to be tracked in this case.